### PR TITLE
Firmware Stepper Motor Optimizations

### DIFF
--- a/micro-controller-firmware/.vscode/extensions.json
+++ b/micro-controller-firmware/.vscode/extensions.json
@@ -2,8 +2,11 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "platformio.platformio-ide",
         "bierner.markdown-mermaid",
+        "ms-vscode.cpptools-extension-pack",
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
         "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/micro-controller-firmware/.vscode/extensions.json
+++ b/micro-controller-firmware/.vscode/extensions.json
@@ -5,8 +5,5 @@
         "bierner.markdown-mermaid",
         "ms-vscode.cpptools-extension-pack",
         "platformio.platformio-ide"
-    ],
-    "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/micro-controller-firmware/src/car.cpp
+++ b/micro-controller-firmware/src/car.cpp
@@ -118,11 +118,13 @@ void SteeringMotor::updatePosition()
 
   if (!motorEnabled)
   {
+    correctionActive = false;
     return;
   }
 
   float currentAngle = normalizeAngle(getSteeringAngle() - angleOffset);
   float error = normalizeAngle(targetAngle - currentAngle);
+  float absoluteError = fabsf(error);
 
   if (fabsf(currentAngle - lastExternalAngle) < SMALL_MOVEMENT_THRESHOLD)
   {
@@ -136,7 +138,6 @@ void SteeringMotor::updatePosition()
 
   float stepsPerRev = MOTOR_STEPS * MICROSTEPS;
   int32_t currentSteps = (int32_t)((currentAngle / 360.0f) * stepsPerRev * STEERING_GEAR_RATIO);
-  int32_t targetSteps = (int32_t)((targetAngle / 360.0f) * stepsPerRev * STEERING_GEAR_RATIO);
 
   if (stallCounter > STALL_DETECTION_COUNT)
   {
@@ -144,12 +145,19 @@ void SteeringMotor::updatePosition()
     stallCounter = 0;
   }
 
-  if (fabsf(error) > STEERING_MAX_ALLOWED_ERROR && fabsf(carSpeed) > 0.1f)
+  if (correctionActive)
+  {
+    correctionActive = absoluteError > STEERING_CORRECTION_STOP_ERROR_DEG;
+  }
+  else
+  {
+    correctionActive = absoluteError > STEERING_CORRECTION_START_ERROR_DEG;
+  }
+
+  if (correctionActive && fabsf(carSpeed) > 0.1f)
   {
     float maxCorrectionSteps = 200.0f;
     int32_t correctionSteps = (int32_t)(error * stepsPerRev * STEERING_GEAR_RATIO / 360.0f);
-
-    correctionSteps = (int32_t)(correctionSteps * 1.5f);
 
     if (correctionSteps > maxCorrectionSteps)
       correctionSteps = maxCorrectionSteps;
@@ -161,7 +169,7 @@ void SteeringMotor::updatePosition()
   }
   else
   {
-    driver.XTARGET(currentSteps);
+    // Preserve the last correction target inside the hysteresis band.
   }
 }
 

--- a/micro-controller-firmware/src/car.cpp
+++ b/micro-controller-firmware/src/car.cpp
@@ -53,7 +53,23 @@ float SteeringMotor::normalizeAngle(float angle) const
 
 float SteeringMotor::getSteeringAngle() const
 {
-  int raw = analogRead(STEERING_SENSOR_PIN);
+  int samples[5];
+  for (int i = 0; i < 5; i++)
+    samples[i] = analogRead(STEERING_SENSOR_PIN);
+
+  for (int i = 1; i < 5; i++)
+  {
+    int value = samples[i];
+    int j = i - 1;
+    while (j >= 0 && samples[j] > value)
+    {
+      samples[j + 1] = samples[j];
+      j--;
+    }
+    samples[j + 1] = value;
+  }
+
+  int raw = samples[2];
   float angle = ((float)raw / STEERING_SENSOR_MAX_VALUE) * DEGREES_PER_REVOLUTION;
   return angle;
 }

--- a/micro-controller-firmware/src/car.cpp
+++ b/micro-controller-firmware/src/car.cpp
@@ -13,9 +13,7 @@ void SteeringMotor::begin()
   driver.microsteps(MICROSTEPS);
   driver.RAMPMODE(0);
 
-  driver.rms_current(200);
-  driver.ihold(3);
-  driver.irun(15);
+  driver.rms_current(STEERING_RUN_CURRENT_MA, STEERING_HOLD_MULTIPLIER);
   driver.iholddelay(5);
 
   driver.en_pwm_mode(true);
@@ -85,16 +83,6 @@ void SteeringMotor::setCarSpeed(float speed)
 void SteeringMotor::enableMotor(bool enable)
 {
   motorEnabled = enable;
-  if (enable)
-  {
-    driver.ihold(5);
-    driver.irun(50);
-  }
-  else
-  {
-    driver.ihold(0);
-    driver.irun(0);
-  }
 }
 
 void SteeringMotor::setEncoderOffset(float offset)
@@ -175,9 +163,7 @@ void DriveMotor::begin()
   driver.shaft(true);
   driver.X_ENC(0);
 
-  driver.rms_current(600);
-  driver.ihold(5);
-  driver.irun(20);
+  driver.rms_current(DRIVE_RUN_CURRENT_MA, DRIVE_HOLD_MULTIPLIER);
   driver.iholddelay(5);
 
   driver.en_pwm_mode(true);

--- a/micro-controller-firmware/src/car.cpp
+++ b/micro-controller-firmware/src/car.cpp
@@ -39,6 +39,7 @@ void SteeringMotor::begin()
   driver.d1(1000);
   driver.VSTOP(10);
 
+  enableMotor(false);
   lastCorrectionMicros = micros();
 }
 
@@ -83,6 +84,7 @@ void SteeringMotor::setTargetAngle(float angle)
   }
 
   targetAngle = newTargetAngle;
+  enableMotor(true);
 
   float stepsPerRev = MOTOR_STEPS * MICROSTEPS;
   float currentAngle = normalizeAngle(getSteeringAngle() - angleOffset);
@@ -99,6 +101,10 @@ void SteeringMotor::setCarSpeed(float speed)
 void SteeringMotor::enableMotor(bool enable)
 {
   motorEnabled = enable;
+  driver.toff(enable ? 4 : 0);
+
+  if (!enable)
+    correctionActive = false;
 }
 
 void SteeringMotor::setEncoderOffset(float offset)
@@ -110,15 +116,11 @@ void SteeringMotor::updatePosition()
 {
   uint32_t now = micros();
 
-  bool shouldEnable = fabsf(carSpeed) > 0.1f;
-  if (shouldEnable != motorEnabled)
-  {
-    enableMotor(shouldEnable);
-  }
+  if (fabsf(carSpeed) > 0.1f && !motorEnabled)
+    enableMotor(true);
 
   if (!motorEnabled)
   {
-    correctionActive = false;
     return;
   }
 
@@ -154,7 +156,7 @@ void SteeringMotor::updatePosition()
     correctionActive = absoluteError > STEERING_CORRECTION_START_ERROR_DEG;
   }
 
-  if (correctionActive && fabsf(carSpeed) > 0.1f)
+  if (correctionActive)
   {
     float maxCorrectionSteps = 200.0f;
     int32_t correctionSteps = (int32_t)(error * stepsPerRev * STEERING_GEAR_RATIO / 360.0f);
@@ -167,9 +169,9 @@ void SteeringMotor::updatePosition()
     int32_t newTargetSteps = currentSteps + correctionSteps;
     driver.XTARGET(newTargetSteps);
   }
-  else
+  else if (fabsf(carSpeed) <= 0.1f)
   {
-    // Preserve the last correction target inside the hysteresis band.
+    enableMotor(false);
   }
 }
 

--- a/micro-controller-firmware/src/car.cpp
+++ b/micro-controller-firmware/src/car.cpp
@@ -39,7 +39,6 @@ void SteeringMotor::begin()
   driver.d1(1000);
   driver.VSTOP(10);
 
-  enableMotor(false);
   lastCorrectionMicros = micros();
 }
 
@@ -84,7 +83,6 @@ void SteeringMotor::setTargetAngle(float angle)
   }
 
   targetAngle = newTargetAngle;
-  enableMotor(true);
 
   float stepsPerRev = MOTOR_STEPS * MICROSTEPS;
   float currentAngle = normalizeAngle(getSteeringAngle() - angleOffset);
@@ -101,10 +99,6 @@ void SteeringMotor::setCarSpeed(float speed)
 void SteeringMotor::enableMotor(bool enable)
 {
   motorEnabled = enable;
-  driver.toff(enable ? 4 : 0);
-
-  if (!enable)
-    correctionActive = false;
 }
 
 void SteeringMotor::setEncoderOffset(float offset)
@@ -116,11 +110,15 @@ void SteeringMotor::updatePosition()
 {
   uint32_t now = micros();
 
-  if (fabsf(carSpeed) > 0.1f && !motorEnabled)
-    enableMotor(true);
+  bool shouldEnable = fabsf(carSpeed) > 0.1f;
+  if (shouldEnable != motorEnabled)
+  {
+    enableMotor(shouldEnable);
+  }
 
   if (!motorEnabled)
   {
+    correctionActive = false;
     return;
   }
 
@@ -156,7 +154,7 @@ void SteeringMotor::updatePosition()
     correctionActive = absoluteError > STEERING_CORRECTION_START_ERROR_DEG;
   }
 
-  if (correctionActive)
+  if (correctionActive && fabsf(carSpeed) > 0.1f)
   {
     float maxCorrectionSteps = 200.0f;
     int32_t correctionSteps = (int32_t)(error * stepsPerRev * STEERING_GEAR_RATIO / 360.0f);
@@ -169,9 +167,9 @@ void SteeringMotor::updatePosition()
     int32_t newTargetSteps = currentSteps + correctionSteps;
     driver.XTARGET(newTargetSteps);
   }
-  else if (fabsf(carSpeed) <= 0.1f)
+  else
   {
-    enableMotor(false);
+    // Preserve the last correction target inside the hysteresis band.
   }
 }
 

--- a/micro-controller-firmware/src/car.cpp
+++ b/micro-controller-firmware/src/car.cpp
@@ -99,6 +99,7 @@ void SteeringMotor::setCarSpeed(float speed)
 void SteeringMotor::enableMotor(bool enable)
 {
   motorEnabled = enable;
+  driver.toff(enable ? 4 : 0);
 }
 
 void SteeringMotor::setEncoderOffset(float offset)

--- a/micro-controller-firmware/src/car.h
+++ b/micro-controller-firmware/src/car.h
@@ -49,7 +49,7 @@ public:
   float lastExternalAngle = 0.0f;
   int stallCounter = 0;
   float carSpeed = 0.0f;
-  bool motorEnabled = true;
+  bool motorEnabled = false;
   bool correctionActive = false;
 
   SteeringMotor(int cs);

--- a/micro-controller-firmware/src/car.h
+++ b/micro-controller-firmware/src/car.h
@@ -20,7 +20,7 @@
 #define MOTOR_STEPS 200
 #define MICROSTEPS 16
 
-#define STEERING_RUN_CURRENT_MA 400
+#define STEERING_RUN_CURRENT_MA 350
 #define STEERING_HOLD_MULTIPLIER 0.20f
 #define DRIVE_RUN_CURRENT_MA 800
 #define DRIVE_HOLD_MULTIPLIER 0.30f
@@ -33,7 +33,8 @@
 // Steering control parameters
 #define STEERING_CORRECTION_INTERVAL 10000
 #define STEERING_GEAR_RATIO (55.0f / 12.0f)
-#define STEERING_MAX_ALLOWED_ERROR 1.5f
+#define STEERING_CORRECTION_START_ERROR_DEG 1.5f
+#define STEERING_CORRECTION_STOP_ERROR_DEG 1.0f
 #define STALL_DETECTION_COUNT 8
 #define SMALL_MOVEMENT_THRESHOLD 0.2f
 
@@ -49,6 +50,7 @@ public:
   int stallCounter = 0;
   float carSpeed = 0.0f;
   bool motorEnabled = true;
+  bool correctionActive = false;
 
   SteeringMotor(int cs);
   void begin();

--- a/micro-controller-firmware/src/car.h
+++ b/micro-controller-firmware/src/car.h
@@ -7,18 +7,23 @@
 #include <limits.h>
 
 // SPI pin definitions
-#define CS_STEER    41
-#define CS_RIGHT    39
-#define CS_LEFT     40
-#define MOSI_PIN    11
-#define MISO_PIN    13
-#define SCK_PIN     12
-#define EN_PIN       4
+#define CS_STEER 41
+#define CS_RIGHT 39
+#define CS_LEFT 40
+#define MOSI_PIN 11
+#define MISO_PIN 13
+#define SCK_PIN 12
+#define EN_PIN 4
 
 // Stepper and driver parameters
 #define R_SENSE 0.075f
 #define MOTOR_STEPS 200
 #define MICROSTEPS 16
+
+#define STEERING_RUN_CURRENT_MA 400
+#define STEERING_HOLD_MULTIPLIER 0.20f
+#define DRIVE_RUN_CURRENT_MA 800
+#define DRIVE_HOLD_MULTIPLIER 0.30f
 
 // Steering sensor parameters
 #define STEERING_SENSOR_PIN 18
@@ -27,12 +32,13 @@
 
 // Steering control parameters
 #define STEERING_CORRECTION_INTERVAL 10000
-#define STEERING_GEAR_RATIO (55.0f/12.0f)
+#define STEERING_GEAR_RATIO (55.0f / 12.0f)
 #define STEERING_MAX_ALLOWED_ERROR 1.5f
 #define STALL_DETECTION_COUNT 8
 #define SMALL_MOVEMENT_THRESHOLD 0.2f
 
-class SteeringMotor {
+class SteeringMotor
+{
 public:
   TMC5160Stepper driver;
   int cs_pin;
@@ -43,7 +49,7 @@ public:
   int stallCounter = 0;
   float carSpeed = 0.0f;
   bool motorEnabled = true;
-  
+
   SteeringMotor(int cs);
   void begin();
   void setTargetAngle(float angle);
@@ -55,22 +61,23 @@ public:
   float normalizeAngle(float angle) const;
 };
 
-class DriveMotor {
+class DriveMotor
+{
 public:
   TMC5160Stepper driver;
   int cs_pin;
   uint32_t target_steps_per_sec = 0;
   uint32_t last_time = 0;
   float target_rpm = 0.0f;
-  
+
   // Control loop variables
   int32_t last_enc = 0;
   float step_rate_cmd = 0.0f;
   float current_rpm = 0.0f;
-  
+
   // Non-blocking control state
   bool driver_ready = true;
-  
+
   // Control constants
   static const int ENCODER_TICKS_PER_REVOLUTION = 4096;
 
@@ -81,8 +88,8 @@ public:
   float getCurrentRPM() const;
 };
 
-
-class Car {
+class Car
+{
 public:
   float speed = 0.0f;
   float steeringAngle = 0.0f;
@@ -112,4 +119,4 @@ private:
   void applyMotorSpeeds();
 };
 
-#endif // CAR_H   
+#endif // CAR_H

--- a/micro-controller-firmware/src/car.h
+++ b/micro-controller-firmware/src/car.h
@@ -49,7 +49,7 @@ public:
   float lastExternalAngle = 0.0f;
   int stallCounter = 0;
   float carSpeed = 0.0f;
-  bool motorEnabled = false;
+  bool motorEnabled = true;
   bool correctionActive = false;
 
   SteeringMotor(int cs);


### PR DESCRIPTION
**PR Details**

**Description**

This PR improves the TMC5160 stepper motor current configuration and steering feedback behavior for the CDA1Tenth ESP32-S3 firmware.

**Motor Current Configuration:**

**car.cpp/car.h**: Replaces direct `I_RUN` and `I_HOLD` register settings with named RMS current values.

- Steering motor configured for 350 mA RMS with a 20% hold multiplier
- Drive motors configured for 800 mA RMS with a 30% hold multiplier
- Removes the invalid steering `I_RUN=50` configuration
- Uses the TMC5160 `toff` setting to disable the steering output stage below the existing vehicle-speed threshold
- Restores the configured chopper setting when steering is enabled

**Steering Feedback:**

- Adds a five-sample median filter to the analog steering encoder reading to reject isolated noisy samples
- Adds steering correction hysteresis
- Steering correction begins above 1.5 degrees of error
- Steering correction continues until error falls below 1.0 degree
- Removes the previous 1.5x correction scaling to reduce steering overshoot
- Preserves the final correction target while inside the hysteresis range

**Supporting Configuration:**

N/A

**Related GitHub Issue**

N/A

**Related Jira Key**

N/A

**Motivation and Context**

The previous steering motor configuration could draw excessive current because the RMS current configuration was overwritten with direct `I_RUN` and `I_HOLD` register values. The steering enable path also attempted to set `I_RUN` to 50 even though the TMC5160 current-scale field only supports values from 0 through 31.

The steering encoder can also produce noisy analog readings. These readings may cause unnecessary steering corrections or unstable behavior near the allowed steering-error threshold.

This change makes motor current settings explicit in milliamps, disables steering coil output when steering is inactive, filters isolated encoder noise, and adds hysteresis to prevent steering correction from repeatedly toggling around a single threshold.

**How Has This Been Tested?**

**Firmware Build Testing**: Successfully compiled with PlatformIO for the ESP32-S3 target.

**Hardware Testing**: Flashed the firmware to the CDA1Tenth ESP32-S3 controller and used the Bluetooth control interface to send drive and steering commands.

**Motor Control Testing**: Exercised the left and right drive motors and steering motor using Bluetooth commands. Verified that the updated current configuration initializes correctly and that steering responds to encoder feedback.

**Power Testing**: Confirmed that the excessive steering current draw was reduced after replacing the raw current register values. Verified that the steering output stage is disabled below the existing speed threshold.

**Steering Feedback Testing**: Exercised steering commands through the Bluetooth controller to evaluate encoder filtering, steering correction, and behavior near the target angle.

**Types of changes**

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)

**Checklist**

- [ ] I have added any new packages to the sonar-scanner.properties file. (N/A: no packages were added.)
- [ ] My change requires a change to the documentation. (N/A: no documentation changes are required.)
- [ ] I have updated the documentation accordingly. (N/A)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes. (No automated motor-control tests are currently available.)
- [x] All new and existing firmware builds passed.

**Note:** The motor-control changes were tested on the physical vehicle using Bluetooth commands. Automated unit tests could be added in the future for current configuration, encoder filtering, and steering correction behavior.